### PR TITLE
#189 customer/ordersのnewとconfirmとthanksの編集

### DIFF
--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -1,5 +1,8 @@
+<div class="container">
+  <div class="row">
 <h2>注文情報確認</h2>
-<table>
+<div class="col-sm-9">
+<table class="detail">
     <thead>
         <tr>
             <th>商品</th>
@@ -13,7 +16,7 @@
         <% @cart_items.each do |cart_item| %>
             <tr>
                 <td>
-                    </textarea><%= attachment_image_tag(cart_item.product, :product_image, :fill, 30, 30) %>
+                    <%= attachment_image_tag(cart_item.product, :product_image, :fill, 30, 30) %>
                     <%= cart_item.product.name %>
                 </td>
                 <td>
@@ -28,8 +31,10 @@
             </tr>
         <% end %>
     </tbody>
-</table> 
-<table>
+</table>
+</div>
+<div class="col-xs-3">
+<table class="price">
     <tr>
         <th>送料</th>
         <td><%= @delivery_fee %></td>
@@ -43,15 +48,27 @@
         <td><%= @delivery_fee + @billing_amount %></td>
     </tr>
 </table>
-
-<h2>支払い方法</h2>
+</div>
+</div>
+<div class="row">
+<ul class="confirm">
+<li><h3><strong>支払い方法</strong></h3></li>
     <% if(@payment == 0) %>
-        <%= "クレジットカード" %>
+        <li><h3><%= "クレジットカード" %></h3></li>
     <% else %>
-        <%= "銀行振込" %>
+       <li><h3> <%= "銀行振込" %></h3></li>
     <% end %>
-<h2>お届け先</h2><%= "〒" + @postcode + @address + @recipient %>
-
+</ul>
+<ul class="confirm">
+<li><h3><strong>お届け先</strong></h3></li>
+    <li><h3><%= "〒" + @postcode %></h3></li>
+    <li><h3><%= @address %></h3></li>
+    <li><h3><%= @recipient %></h3></li>
+</ul>
+</div>
+<div class="row">
+    <div class="col-xs-6">
+        <div class="enter">
 <%# hidden_fieldを用いて、createアクションにパラメータを送信する %>
 <%= form_with(model: @order, url: orders_path, local: true) do |f| %>
     <%= f.hidden_field :recipient, value: @recipient %>
@@ -60,7 +77,78 @@
     <%= f.hidden_field :delivery_fee, value: @delivery_fee %>
     <%= f.hidden_field :billing_amount, value: @billing_amount %>
     <%= f.hidden_field :payment, value: @payment %>
-    <%= f.submit("購入を確定する", class: "btn btn-default") %>
+    <%= f.submit("購入を確定する", class: "btn btn-primary 30px") %>
 <% end %> 
+</div>
+</div>
+<div class="col-xs-6">
+    <div class="back">
+<%= link_to('戻る',cart_items_path, class: "btn btn-danger 30px") %>
+</div>
+</div>
+</div>
+</div>
 
-<%= link_to('戻る',cart_items_path, class: "btn btn-danger") %>
+
+
+<style>
+.detail {
+width: 80%;
+}
+
+.detail th {
+border: 1px solid #ccc;
+padding: 10px;
+font-size: 18px;
+background-color: #dedede;
+width: 100px;
+}
+
+.detail td {
+border: 1px solid #ccc;
+padding: 10px;
+font-size: 18px;
+width: 250px;
+}
+.price{
+    width: 100%;
+}
+.price th {
+border: 1px solid #ccc;
+padding: 10px;
+font-size: 18px;
+background-color: #dedede;
+width: 100px;
+}
+
+.price td {
+border: 1px solid #ccc;
+padding: 10px;
+font-size: 18px;
+width: 100px;
+}
+ul {
+    list-style-type: none;
+    padding: 0;
+    margin:0;
+}
+
+.confirm li{
+    display: inline-block;
+    margin-top: 20px;
+}
+.confirm li h3{
+    padding: 0;
+    text-indent: 0;
+    margin-right: 10px;
+}
+
+.enter {
+    margin-top: 50px;
+    margin-left: 500px;
+}
+.back {
+    margin-top: 50px;
+    margin-left: 500px;
+}
+</style>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,26 +1,79 @@
+<div class="container">
+  <div class="row">
 <h2>購入情報入力</h2>
 
 <%# confirmコントローラでordersモデルに保存する値を判定するため、引数にモデルを定義しない %>
 <%= form_with(url: orders_cofirm_path, local: true, method: :post) do |f| %>
-    <h3>支払方法</h3>
-    <label><%= f.radio_button :payment, 0 %>クレジットカード</label>
-    <label><%= f.radio_button :payment, 1 %>銀行振込</label>
+    <div class="title">支払方法</div>
+    <div class="btn"><%= f.radio_button :payment, 0 %>クレジットカード</div>
+    <br>
+    <div class="btn"><%= f.radio_button :payment, 1 %>銀行振込</div>
 
     <%# radio_button_tagでaddress_typeの値を送信し、コントローラーでorderに保存するpostcode, address, recipientを判断する %>
-    <h3>お届け先</h3>
-    <label><%= f.radio_button(:address_type, 0) %>ご自身の住所</label>
+    <div class="title">お届け先</div>
+    <div class="btn"><%= f.radio_button(:address_type, 0) %>ご自身の住所
+    <br>
     <%= "〒" + current_customer.postcode %>
+    <br>
     <%= current_customer.address %>
-    <%= current_customer.first_name + " " + current_customer.last_name %>
-
+    <%= current_customer.first_name + " " + current_customer.last_name %></div>
+    <br>
     <%# current_userに紐付くshipping_addressを@addressに代入し、collection_selectで表示する %>
-    <label><%= f.radio_button(:address_type, 1) %>登録済住所から選択</label>
-    <%= f.collection_select(:existing_address, @addresses, :id, :postcode ,include_blank: '選択してください') %>
-
-    <label><%= f.radio_button(:address_type, 2) %>新しいお届け先</label>
-    <label>郵便番号<%= f.text_field(:new_postcode) %></label><p>ハイフンなし</p>
-    <label>住所<%= f.text_field(:new_address) %></label>
-    <label>宛名<%= f.text_field(:new_recipient) %></label>
-
+    <div class="btn"><%= f.radio_button(:address_type, 1) %>登録済住所から選択</div>
+    <br>
+    <!-- selectのsizeの指定をするとinclude_blankの”選択してください”が下に表示されてしまいます。 -->
+    <%= f.collection_select(:existing_address, @addresses, :id, :postcode ,include_blank: '選択してください',class: "500px") %>
+    </div>
+    <br>
+    <div class="btn"><%= f.radio_button(:address_type, 2) %>新しいお届け先</div>
+    <table class="new">
+        <tr>
+            <th>郵便番号</th>
+            <td><%= f.text_field(:new_postcode,class: "col-xs-2") %>  ハイフンなし</td>
+        </tr>
+        <tr>
+            <th>住所</th>
+            <td><%= f.text_field(:new_address,class: "col-xs-8") %></td>
+        </tr>
+        <tr>
+            <th>宛名</th>
+            <td><%= f.text_field(:new_recipient,class: "col-xs-3") %></td>
+        </tr>
+    </table>
+    <div class="ver">
     <%= f.submit("確認画面へ進む", class: "btn btn-primary") %>
-<% end %> 
+</div>
+<% end %>
+</div>
+</div>
+
+<style>
+.title{
+    font-size: 25px;
+    font-weight: bold;
+}
+.btn{
+    margin-left: 50px;
+    font-size: 18px;
+}
+
+.new {
+width: 100%;
+}
+
+.new th {
+padding: 5px;
+font-size: 18px;
+width: 50px;
+}
+
+.new td {
+padding: 5px;
+font-size: 18px;
+width: 250px;
+}
+
+.ver {
+    padding-left: 400px;
+}
+</style>

--- a/app/views/orders/thanks.html.erb
+++ b/app/views/orders/thanks.html.erb
@@ -1,1 +1,16 @@
+<div class="container">
+  <div class="row">
+<div class="thanks">
 <strong>ご購入ありがとうございました！</strong>
+</div>
+</div>
+</div>
+
+<style>
+.thanks{
+	margin-top: 300px;
+	margin-left: 350px;
+	font-size: 30px;
+	font-weight: bold;
+}
+</style>


### PR DESCRIPTION
customer/ordersのnewとconfirmとthanksの編集
newページの
 <%= f.collection_select(:existing_address, @addresses, :id, :postcode ,include_blank: '選択してください'　>
にsizeを指定するとinclude_blank: '選択してください'が直下に表示されてしまいます。
select classなどで指定しても上手く行きませんでした。
ディベロッパーツールで検証して一度確認してください。